### PR TITLE
Small cleanup, also a "maybe" solution to the enum problem you seemed to face.

### DIFF
--- a/VerbalExpressions/CommonRegex.cs
+++ b/VerbalExpressions/CommonRegex.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VerbalExpression.Net
+{
+
+    /// <summary>
+    /// This class is used to fake an enum. You'll be able to use it as an enum.
+    /// Note: type save enum, found on stackoverflow: http://stackoverflow.com/a/424414/603309
+    /// </summary>
+    public sealed class CommonRegex
+    {
+
+        private readonly String name;
+        private readonly int value;
+
+        public static readonly CommonRegex Url = new CommonRegex(1, @"((([A-Za-z]{3,9}:(?:\/\/)?)(?:[^-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:ww‌​w.|[^-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?‌​(?:[\w]*))?)");
+        public static readonly CommonRegex Email = new CommonRegex(2, @"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}");
+        
+        private CommonRegex(int value, String name)
+        {
+            this.name = name;
+            this.value = value;
+        }
+
+        public int ToSwitchableValue()
+        {
+            return value;
+        }
+
+        public override String ToString()
+        {
+            return name;
+        }
+
+    }
+}

--- a/VerbalExpressions/VerbalExpressions.cs
+++ b/VerbalExpressions/VerbalExpressions.cs
@@ -12,313 +12,291 @@ using System.Text.RegularExpressions;
 
 namespace VerbalExpression.Net
 {
-	public class VerbalExpressions
-	{
-		private string _prefixes = "";
-		private string _source = "";
-		private string _suffixes = "";
+    public class VerbalExpressions
+    {
+        private string _prefixes = "";
+        private string _source = "";
+        private string _suffixes = "";
 
-		private RegexOptions _modifiers = RegexOptions.Multiline;
-		private Regex patternRegex;
+        private RegexOptions _modifiers = RegexOptions.Multiline;
+        private Regex patternRegex;
 
-        private const string UrlRegEx = @"((([A-Za-z]{3,9}:(?:\/\/)?)(?:[^-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:ww‌​w.|[^-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?‌​(?:[\w]*))?)";
-        private const string EmailRegEx = @"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}";
-        //private const string UrlRegEx = @"abc";
-        //private const string EmailRegEx = @"[def]";
-
-		private string Sanitize(string value)
-		{
-			if (value == null) 
-				return string.Empty;
-			return Regex.Escape(value);
-		}
-
-        public const VerbalExpressionsEnum email = VerbalExpressionsEnum.email;
-        public const VerbalExpressionsEnum url = VerbalExpressionsEnum.url;
-
-	    public VerbalExpressions Add(VerbalExpressionsEnum verbEx)
-	    {
-	        var value = GetRegex(verbEx);
-			return Add(value, sanitize:false);
-		}
-
-	    public VerbalExpressions Add(string value, bool sanitize = true)
-		{
-		    value = sanitize ? Sanitize(value) : value;
-			_source = _source != null ? _source + value : value;
-			if (_source != null)
-				patternRegex = new Regex(_prefixes + _source + _suffixes, _modifiers);
-
-			return this;
-		}
-
-		public VerbalExpressions StartOfLine(bool enable = true)
-		{
-			_prefixes = enable ? "^" : "";
-			return this;
-		}
-
-		public VerbalExpressions EndOfLine(bool enable = true)
-		{
-			_suffixes = enable ? "$" : "";
-			return this;
-		}
-
-		public VerbalExpressions Then(string value, bool sanitize = true)
-		{
-		    value = sanitize ? Sanitize(value) : value;
-            Add("(" + value + ")", sanitize: false);
-			return this;
-		}
-
-        public VerbalExpressions Then(VerbalExpressionsEnum verbExEnum)
+        private string Sanitize(string value)
         {
-            var value = GetRegex(verbExEnum);
-            return Then(value, sanitize: false);
+            if (value == null)
+                return string.Empty;
+            return Regex.Escape(value);
+        }
+        
+        public VerbalExpressions Add(CommonRegex commonRegex)
+        {
+            return Add(commonRegex.ToString(), sanitize: false);
+        }
+
+        public VerbalExpressions Add(string value, bool sanitize = true)
+        {
+            value = sanitize ? Sanitize(value) : value;
+            _source = _source != null ? _source + value : value;
+            if (_source != null)
+                patternRegex = new Regex(_prefixes + _source + _suffixes, _modifiers);
+
+            return this;
+        }
+
+        public VerbalExpressions StartOfLine(bool enable = true)
+        {
+            _prefixes = enable ? "^" : "";
+            return this;
+        }
+
+        public VerbalExpressions EndOfLine(bool enable = true)
+        {
+            _suffixes = enable ? "$" : "";
+            return this;
+        }
+
+        public VerbalExpressions Then(string value, bool sanitize = true)
+        {
+            value = sanitize ? Sanitize(value) : value;
+            Add("(" + value + ")", sanitize: false);
+            return this;
+        }
+
+        public VerbalExpressions Then(CommonRegex commonRegex)
+        {
+            return Then(commonRegex.ToString(), sanitize: false);
         }
 
         public VerbalExpressions Find(string value)
-		{
-			Then(value);
-			return this;
-		}
-
-		public VerbalExpressions Maybe(string value, bool sanitize = true)
-		{
-			value = sanitize ? Sanitize(value) : value;
-            Add("(" + value + ")?", sanitize: false);
-			return this;
-		}
-
-        public VerbalExpressions Maybe(VerbalExpressionsEnum verbExEnum)
         {
-            var value = GetRegex(verbExEnum);
-            return Maybe(value, sanitize: false);
+            Then(value);
+            return this;
         }
 
-		public VerbalExpressions Anything()
-		{
-			Add("(.*)", sanitize: false);
-			return this;
-		}
+        public VerbalExpressions Maybe(string value, bool sanitize = true)
+        {
+            value = sanitize ? Sanitize(value) : value;
+            Add("(" + value + ")?", sanitize: false);
+            return this;
+        }
 
-		public VerbalExpressions AnythingBut(string value, bool sanitize = true)
-		{
+        public VerbalExpressions Maybe(CommonRegex commonRegex)
+        {
+            return Maybe(commonRegex.ToString(), sanitize: false);
+        }
+
+        public VerbalExpressions Anything()
+        {
+            Add("(.*)", sanitize: false);
+            return this;
+        }
+
+        public VerbalExpressions AnythingBut(string value, bool sanitize = true)
+        {
             value = sanitize ? Sanitize(value) : value;
             Add("([^" + value + "]*)", sanitize: false);
-			return this;
-		}
+            return this;
+        }
 
-		public VerbalExpressions Replace(string value)
-		{
-			_source.Replace(patternRegex.ToString(), value);
-			return this;
-		}
+        public VerbalExpressions Replace(string value)
+        {
+            _source.Replace(patternRegex.ToString(), value);
+            return this;
+        }
 
-		public VerbalExpressions LineBreak()
-		{
-			Add("(\\n|(\\r\\n))", sanitize:false);
-			return this;
-		}
+        public VerbalExpressions LineBreak()
+        {
+            Add("(\\n|(\\r\\n))", sanitize: false);
+            return this;
+        }
 
-		public VerbalExpressions Br()
-		{
-			LineBreak();
-			return this;
-		}
+        public VerbalExpressions Br()
+        {
+            LineBreak();
+            return this;
+        }
 
-		public VerbalExpressions Tab()
-		{
-			Add("\\t");
-			return this;
-		}
+        public VerbalExpressions Tab()
+        {
+            Add("\\t");
+            return this;
+        }
 
-		public VerbalExpressions Word()
-		{
-			Add("\\w+", sanitize:false);
-			return this;
-		}
+        public VerbalExpressions Word()
+        {
+            Add("\\w+", sanitize: false);
+            return this;
+        }
 
-		public VerbalExpressions AnyOf(string value)
-		{
-			value = Sanitize(value);
+        public VerbalExpressions AnyOf(string value)
+        {
+            value = Sanitize(value);
             Add("[" + value + "]", sanitize: false);
-			return this;
-		}
+            return this;
+        }
 
-		public VerbalExpressions Any(string value)
-		{
-			AnyOf(value);
-			return this;
-		}
+        public VerbalExpressions Any(string value)
+        {
+            AnyOf(value);
+            return this;
+        }
 
-		public VerbalExpressions Range(object[] args)
-		{
-			string value = "[";
-			for (int _from = 0; _from < args.Length; _from += 2)
-			{
-				int _to = _from + 1;
-				if (args.Length <= _to) break;
-				string from = Sanitize((string)args[_from]);
-				string to = Sanitize((string)args[_to]);
+        public VerbalExpressions Range(object[] args)
+        {
+            string value = "[";
+            for (int _from = 0; _from < args.Length; _from += 2)
+            {
+                int _to = _from + 1;
+                if (args.Length <= _to) break;
+                string from = Sanitize((string)args[_from]);
+                string to = Sanitize((string)args[_to]);
 
-				value += from + "-" + to;
-			}
+                value += from + "-" + to;
+            }
 
-			value += "]";
+            value += "]";
 
             Add(value, sanitize: false);
-			return this;
-		}
+            return this;
+        }
 
-		public VerbalExpressions AddModifier(char modifier)
-		{
-			switch (modifier)
-			{
-				//case 'd':
-				//	_modifiers |= RegexOptions.UNIX_LINES;
-				//	break;
-				case 'i':
-					_modifiers |= RegexOptions.IgnoreCase;
-					break;
-				case 'x':
-					_modifiers |= RegexOptions.IgnorePatternWhitespace;
-					break;
-				case 'm':
-					_modifiers |= RegexOptions.Multiline;
-					break;
-				//case 's':
-				//	_modifiers |= RegexOptions.DOTALL;
-				//	break;
-				//case 'u':
-				//	_modifiers |= Pattern.UNICODE_CASE;
-				//	break;
-				//case 'U':
-				//	_modifiers |= Pattern.UNICODE_CHARACTER_CLASS;
-				//	break;
-			}
+        public VerbalExpressions AddModifier(char modifier)
+        {
+            switch (modifier)
+            {
+                //case 'd':
+                //	_modifiers |= RegexOptions.UNIX_LINES;
+                //	break;
+                case 'i':
+                    _modifiers |= RegexOptions.IgnoreCase;
+                    break;
+                case 'x':
+                    _modifiers |= RegexOptions.IgnorePatternWhitespace;
+                    break;
+                case 'm':
+                    _modifiers |= RegexOptions.Multiline;
+                    break;
+                //case 's':
+                //	_modifiers |= RegexOptions.DOTALL;
+                //	break;
+                //case 'u':
+                //	_modifiers |= Pattern.UNICODE_CASE;
+                //	break;
+                //case 'U':
+                //	_modifiers |= Pattern.UNICODE_CHARACTER_CLASS;
+                //	break;
+            }
 
-			return this;
-		}
+            return this;
+        }
 
-		public VerbalExpressions RemoveModifier(char modifier)
-		{
-			switch (modifier)
-			{
-				//case 'd':
-				//	_modifiers &= ~Pattern.UNIX_LINES;
-				//	break;
-				case 'i':
-					_modifiers &= ~RegexOptions.IgnoreCase;
-					break;
-				case 'x':
-					_modifiers &= ~RegexOptions.IgnorePatternWhitespace;
-					break;
-				case 'm':
-					_modifiers &= ~RegexOptions.Multiline;
-					break;
-				//case 's':
-				//	_modifiers &= ~Pattern.DOTALL;
-				//	break;
-				//case 'u':
-				//	_modifiers &= ~Pattern.UNICODE_CASE;
-				//	break;
-				//case 'U':
-				//	_modifiers &= ~Pattern.UNICODE_CHARACTER_CLASS;
-				//	break;
-				//default:
-				//	break;
-			}
+        public VerbalExpressions RemoveModifier(char modifier)
+        {
+            switch (modifier)
+            {
+                //case 'd':
+                //	_modifiers &= ~Pattern.UNIX_LINES;
+                //	break;
+                case 'i':
+                    _modifiers &= ~RegexOptions.IgnoreCase;
+                    break;
+                case 'x':
+                    _modifiers &= ~RegexOptions.IgnorePatternWhitespace;
+                    break;
+                case 'm':
+                    _modifiers &= ~RegexOptions.Multiline;
+                    break;
+                //case 's':
+                //	_modifiers &= ~Pattern.DOTALL;
+                //	break;
+                //case 'u':
+                //	_modifiers &= ~Pattern.UNICODE_CASE;
+                //	break;
+                //case 'U':
+                //	_modifiers &= ~Pattern.UNICODE_CHARACTER_CLASS;
+                //	break;
+                //default:
+                //	break;
+            }
 
-			return this;
-		}
+            return this;
+        }
 
-		public VerbalExpressions WithAnyCase(bool enable = true)
-		{
-			if (enable) 
+        public VerbalExpressions WithAnyCase(bool enable = true)
+        {
+            if (enable)
                 AddModifier('i');
-			else 
+            else
                 RemoveModifier('i');
-			return this;
-		}
+            return this;
+        }
 
-		public VerbalExpressions SearchOneLine(bool enable = true)
-		{
-			if (enable) 
+        public VerbalExpressions SearchOneLine(bool enable = true)
+        {
+            if (enable)
                 RemoveModifier('m');
-			else 
+            else
                 AddModifier('m');
-			return this;
-		}
+            return this;
+        }
 
-		public VerbalExpressions Multiple(string value)
-		{
-			value = Sanitize(value);
-			switch (value[0])
-			{
-				case '*':
-				case '+':
-					break;
-				default:
-					value += '+';
-				break;
-			}
+        public VerbalExpressions Multiple(string value)
+        {
+            value = Sanitize(value);
+            switch (value[0])
+            {
+                case '*':
+                case '+':
+                    break;
+                default:
+                    value += '+';
+                    break;
+            }
 
             Add(value, sanitize: false);
-			return this;
-		}
+            return this;
+        }
 
+        public VerbalExpressions Or(CommonRegex commonRegex)
+        {
+            Or(commonRegex.ToString(), sanitize: false);
+            return this;
+        }
 
-		public VerbalExpressions Or(VerbalExpressionsEnum verbEx)
-		{
-		    var value = GetRegex(verbEx);
-            Or(value, sanitize:false);
-			return this;
-		}
-
-		public VerbalExpressions Or(string value, bool sanitize = true)
-		{
-			if (_prefixes.IndexOf("(") == -1)
-				_prefixes += "(";
-			if (_suffixes.IndexOf(")") == -1)
-				_suffixes = ")" + _suffixes;
+        public VerbalExpressions Or(string value, bool sanitize = true)
+        {
+            if (_prefixes.IndexOf("(") == -1)
+                _prefixes += "(";
+            if (_suffixes.IndexOf(")") == -1)
+                _suffixes = ")" + _suffixes;
 
             Add(")|(", sanitize: false);
-			if (value != null) 
-                Add(value, sanitize:false);
-			return this;
-		}
-
-		public bool Test(string toTest)
-		{
-			return IsMatch(toTest);
-		}
-
-		public bool IsMatch(string toTest)
-		{
-			Add(string.Empty);
-			return patternRegex.IsMatch(toTest);
-		}
-
-		public Regex ToRegex()
-		{
-			Add(string.Empty);
-			return patternRegex;
-		}
-
-		public override string ToString()
-		{
-			Add(string.Empty);
-			return patternRegex.ToString();
-		}
-
-        private string GetRegex(VerbalExpressionsEnum verbExEnum)
-        {
-            if (verbExEnum == VerbalExpressionsEnum.email)
-                return EmailRegEx;
-            if (verbExEnum == VerbalExpressionsEnum.url)
-                return UrlRegEx;
-            return string.Empty;
+            if (value != null)
+                Add(value, sanitize: false);
+            return this;
         }
-	}
+
+        public bool Test(string toTest)
+        {
+            return IsMatch(toTest);
+        }
+
+        public bool IsMatch(string toTest)
+        {
+            Add(string.Empty);
+            return patternRegex.IsMatch(toTest);
+        }
+
+        public Regex ToRegex()
+        {
+            Add(string.Empty);
+            return patternRegex;
+        }
+
+        public override string ToString()
+        {
+            Add(string.Empty);
+            return patternRegex.ToString();
+        }
+    }
 }

--- a/VerbalExpressions/VerbalExpressions.csproj
+++ b/VerbalExpressions/VerbalExpressions.csproj
@@ -39,9 +39,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommonRegex.cs" />
     <Compile Include="VerbalExpressions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="VerbalExpressionsEnum.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/VerbalExpressionsUnitTests/VerbalExpressionsTests.cs
+++ b/VerbalExpressionsUnitTests/VerbalExpressionsTests.cs
@@ -5,211 +5,211 @@ using VerbalExpression.Net;
 
 namespace VerbalExpressionsUnitTests
 {
-	[TestClass]
-	public class VerbalExpressionsTests
-	{
+    [TestClass]
+    public class VerbalExpressionsTests
+    {
 
-		private VerbalExpressions verbEx;
+        private VerbalExpressions verbEx;
 
-		[TestInitialize]
-		public void Initialize()
-		{
-			verbEx = new VerbalExpressions();
-		}
+        [TestInitialize]
+        public void Initialize()
+        {
+            verbEx = new VerbalExpressions();
+        }
 
-		[TestMethod]
-		public void TestingIfWeHaveAValidURL()
-		{
-			verbEx = new VerbalExpressions()
-						.StartOfLine()
-						.Then( "http" )
-						.Maybe( "s" )
-						.Then( "://" )
-						.Maybe( "www." )
-						.AnythingBut( " " )
+        [TestMethod]
+        public void TestingIfWeHaveAValidURL()
+        {
+            verbEx = new VerbalExpressions()
+                        .StartOfLine()
+                        .Then( "http" )
+                        .Maybe( "s" )
+                        .Then( "://" )
+                        .Maybe( "www." )
+                        .AnythingBut( " " )
                         .Then(".com")
-						.EndOfLine();
+                        .EndOfLine();
 
             var testMe = "https://www.google.com";
-			Assert.IsTrue(verbEx.Test( testMe ), "The URL is incorrect");
-			Console.WriteLine("We have a correct URL ");
-		}
-	
-		[TestMethod]
-		public void StartOfLine_CreatesCorrectRegex()
-		{
-			verbEx.StartOfLine();
-			Assert.AreEqual("^", verbEx.ToString(), "missing start of line regex");
-		}
-	
-		[TestMethod]
-		public void StartOfLine_ThenHttpMaybeWww_DoesMatchHttpInStart()
-		{
-			verbEx.StartOfLine()
-				.Then("http")
-				.Maybe("www");
-
-			var isMatch = Regex.IsMatch("http", verbEx.ToString());
-			Assert.IsTrue(isMatch, "Should match http in start");
-		}
-	
-		[TestMethod]
-		public void StartOfLine_ThenHttpMaybeWww_DoesNotMatchWwwInStart()
-		{
-			verbEx.StartOfLine()
-				.Then("http")
-				.Maybe("www");
-
-			var isMatch = verbEx.IsMatch("www");
-			Assert.IsFalse(isMatch, "Should not match www in start");
-		}
-	
-		[TestMethod]
-		public void EndOfLine_AddDotComtEndOfLine_DoesMatchDotComInEnd()
-		{
-			verbEx.Add(".com")
-				.EndOfLine();
-
-			var isMatch = verbEx.IsMatch("www.google.com");
-			Assert.IsTrue(isMatch, "Should match '.com' in end");
-		}
-	
-		[TestMethod]
-		public void EndOfLine_AddDotComEndOfLine_DoesNotMatchSlashInEnd()
-		{
-			verbEx.Add(".com")
-				.EndOfLine();
-
-			var isMatch = verbEx.IsMatch("http://www.google.com/");
-			Assert.IsFalse(isMatch, "Should not match '/' in end");
-		}
-
-		[TestMethod]
-		public void Add_AddDotCom_DoesNotMatchGoogleComWithoutDot()
-		{
-			verbEx.Add(".com");
-
-			var isMatch = verbEx.IsMatch("http://www.googlecom/");
-			Assert.IsFalse(isMatch, "Should not match 'ecom'");
-		}
-		
+            Assert.IsTrue(verbEx.Test( testMe ), "The URL is incorrect");
+            Console.WriteLine("We have a correct URL ");
+        }
+    
         [TestMethod]
-		public void Or_AddComOrOrg_DoesMatchComAndOrg()
-		{
-			verbEx.Add("com").Or("org");
+        public void StartOfLine_CreatesCorrectRegex()
+        {
+            verbEx.StartOfLine();
+            Assert.AreEqual("^", verbEx.ToString(), "missing start of line regex");
+        }
+    
+        [TestMethod]
+        public void StartOfLine_ThenHttpMaybeWww_DoesMatchHttpInStart()
+        {
+            verbEx.StartOfLine()
+                .Then("http")
+                .Maybe("www");
+
+            var isMatch = Regex.IsMatch("http", verbEx.ToString());
+            Assert.IsTrue(isMatch, "Should match http in start");
+        }
+    
+        [TestMethod]
+        public void StartOfLine_ThenHttpMaybeWww_DoesNotMatchWwwInStart()
+        {
+            verbEx.StartOfLine()
+                .Then("http")
+                .Maybe("www");
+
+            var isMatch = verbEx.IsMatch("www");
+            Assert.IsFalse(isMatch, "Should not match www in start");
+        }
+    
+        [TestMethod]
+        public void EndOfLine_AddDotComtEndOfLine_DoesMatchDotComInEnd()
+        {
+            verbEx.Add(".com")
+                .EndOfLine();
+
+            var isMatch = verbEx.IsMatch("www.google.com");
+            Assert.IsTrue(isMatch, "Should match '.com' in end");
+        }
+    
+        [TestMethod]
+        public void EndOfLine_AddDotComEndOfLine_DoesNotMatchSlashInEnd()
+        {
+            verbEx.Add(".com")
+                .EndOfLine();
+
+            var isMatch = verbEx.IsMatch("http://www.google.com/");
+            Assert.IsFalse(isMatch, "Should not match '/' in end");
+        }
+
+        [TestMethod]
+        public void Add_AddDotCom_DoesNotMatchGoogleComWithoutDot()
+        {
+            verbEx.Add(".com");
+
+            var isMatch = verbEx.IsMatch("http://www.googlecom/");
+            Assert.IsFalse(isMatch, "Should not match 'ecom'");
+        }
+        
+        [TestMethod]
+        public void Or_AddComOrOrg_DoesMatchComAndOrg()
+        {
+            verbEx.Add("com").Or("org");
 
             Console.WriteLine(verbEx);
             Assert.IsTrue(verbEx.IsMatch("org"), "Should match 'org'");
             Assert.IsTrue(verbEx.IsMatch("com"), "Should match 'com'");
-		}
-	    
+        }
+        
         [TestMethod]
-		public void Or_AddComOrOrg_RegexIsAsExpecteds()
-		{
-			verbEx.Add("com").Or("org");
+        public void Or_AddComOrOrg_RegexIsAsExpecteds()
+        {
+            verbEx.Add("com").Or("org");
             
             Assert.AreEqual("(com)|(org)", verbEx.ToString());
-		}
-	
-		[TestMethod]
-		public void Anything_StartOfLineAnythingEndOfline_DoesMatchAnyThing()
-		{
-			verbEx
-				.StartOfLine()
-				.Anything()
-				.EndOfLine();
-			
-			var isMatch = verbEx.IsMatch("'!@#$%¨&*()__+{}'");
-			Assert.IsTrue(isMatch, "Ooops, should match anything");
-		}
-	
-		[TestMethod]
-		public void WithAnyCase_AddwwwWithAnyCase_DoesMatchwWw()
-		{
-			verbEx.Add("www")
-				.WithAnyCase();
-			
-			var isMatch = verbEx.IsMatch("wWw");
-			Assert.IsTrue(isMatch, "Should match any case");
-		}
-	
-		[TestMethod]
-		public void WithAnyCase_SetsCorrectIgnoreCaseRegexOptionAndHasMultiLineRegexOptionAsDefault()
-		{
-			verbEx.WithAnyCase();
-			
-			var regex = verbEx.ToRegex();
-			Assert.IsTrue(regex.Options.HasFlag(RegexOptions.IgnoreCase), "RegexOptions should have ignoreCase");
-			Assert.IsTrue(regex.Options.HasFlag(RegexOptions.Multiline), "RegexOptions should have MultiLine as default");
-		}
-	
-		[TestMethod]
-		public void RemoveModifier_RemoveModifierM_RemovesMulitilineAsDefault()
-		{
-			var regex = verbEx.ToRegex();
-			Assert.IsTrue(regex.Options.HasFlag(RegexOptions.Multiline), "RegexOptions should have MultiLine as default");
-
-			verbEx.RemoveModifier('m');
-			regex = verbEx.ToRegex();
-
-			Assert.IsFalse(regex.Options.HasFlag(RegexOptions.Multiline), "RegexOptions should now have been removed");
-		}
-	
-		[TestMethod]
-		public void WithAnyCase_AddwwwWithAnyCaseFalse_DoesNotMatchwWw()
-		{
-			verbEx.Add("www")
-				.WithAnyCase(false);
-			
-			var isMatch = verbEx.IsMatch("wWw");
-			Assert.IsFalse(isMatch, "Should not match any case");
-		}
-	
-		[TestMethod]
-		public void Then_VerbalExpressionsEmail_DoesMatchEmail()
-		{
-			verbEx.StartOfLine().Then(VerbalExpressions.email);
-			
-			var isMatch = verbEx.IsMatch("test@github.com");
-			Assert.IsTrue(isMatch, "Should match email address");
-		}
-		
+        }
+    
         [TestMethod]
-		public void Then_VerbalExpressionsEmail_DoesNotMatchUrl()
-		{
-			verbEx.StartOfLine().Then(VerbalExpressions.email);
-			
-			var isMatch = verbEx.IsMatch("http://www.google.com");
-			Assert.IsFalse(isMatch, "Should not match url address");
-		}
-	
-		[TestMethod]
-		public void Then_VerbalExpressionsUrl_DoesMatchUrl()
-		{
-			verbEx.StartOfLine().Then(VerbalExpressions.url);
+        public void Anything_StartOfLineAnythingEndOfline_DoesMatchAnyThing()
+        {
+            verbEx
+                .StartOfLine()
+                .Anything()
+                .EndOfLine();
+            
+            var isMatch = verbEx.IsMatch("'!@#$%¨&*()__+{}'");
+            Assert.IsTrue(isMatch, "Ooops, should match anything");
+        }
+    
+        [TestMethod]
+        public void WithAnyCase_AddwwwWithAnyCase_DoesMatchwWw()
+        {
+            verbEx.Add("www")
+                .WithAnyCase();
+            
+            var isMatch = verbEx.IsMatch("wWw");
+            Assert.IsTrue(isMatch, "Should match any case");
+        }
+    
+        [TestMethod]
+        public void WithAnyCase_SetsCorrectIgnoreCaseRegexOptionAndHasMultiLineRegexOptionAsDefault()
+        {
+            verbEx.WithAnyCase();
+            
+            var regex = verbEx.ToRegex();
+            Assert.IsTrue(regex.Options.HasFlag(RegexOptions.IgnoreCase), "RegexOptions should have ignoreCase");
+            Assert.IsTrue(regex.Options.HasFlag(RegexOptions.Multiline), "RegexOptions should have MultiLine as default");
+        }
+    
+        [TestMethod]
+        public void RemoveModifier_RemoveModifierM_RemovesMulitilineAsDefault()
+        {
+            var regex = verbEx.ToRegex();
+            Assert.IsTrue(regex.Options.HasFlag(RegexOptions.Multiline), "RegexOptions should have MultiLine as default");
 
-		    Assert.IsTrue(verbEx.IsMatch("http://www.google.com"), "Should match url address");
-		    Assert.IsTrue(verbEx.IsMatch("https://www.google.com"), "Should match url address");
-		    Assert.IsTrue(verbEx.IsMatch("http://google.com"), "Should match url address");
-		}	
+            verbEx.RemoveModifier('m');
+            regex = verbEx.ToRegex();
 
-		[TestMethod]
-		public void Then_VerbalExpressionsUrl_DoesNotMatchEmail()
-		{
-			verbEx.StartOfLine().Then(VerbalExpressions.url);
+            Assert.IsFalse(regex.Options.HasFlag(RegexOptions.Multiline), "RegexOptions should now have been removed");
+        }
+    
+        [TestMethod]
+        public void WithAnyCase_AddwwwWithAnyCaseFalse_DoesNotMatchwWw()
+        {
+            verbEx.Add("www")
+                .WithAnyCase(false);
+            
+            var isMatch = verbEx.IsMatch("wWw");
+            Assert.IsFalse(isMatch, "Should not match any case");
+        }
+    
+        [TestMethod]
+        public void Then_VerbalExpressionsEmail_DoesMatchEmail()
+        {
+            verbEx.StartOfLine().Then(CommonRegex.Email);
+            
+            var isMatch = verbEx.IsMatch("test@github.com");
+            Assert.IsTrue(isMatch, "Should match email address");
+        }
+        
+        [TestMethod]
+        public void Then_VerbalExpressionsEmail_DoesNotMatchUrl()
+        {
+            verbEx.StartOfLine().Then(CommonRegex.Email);
+            
+            var isMatch = verbEx.IsMatch("http://www.google.com");
+            Assert.IsFalse(isMatch, "Should not match url address");
+        }
+    
+        [TestMethod]
+        public void Then_VerbalExpressionsUrl_DoesMatchUrl()
+        {
+            verbEx.StartOfLine().Then(CommonRegex.Url);
 
-		    Assert.IsFalse(verbEx.IsMatch("test@github.com"), "Should not match email address");
-		}
+            Assert.IsTrue(verbEx.IsMatch("http://www.google.com"), "Should match url address");
+            Assert.IsTrue(verbEx.IsMatch("https://www.google.com"), "Should match url address");
+            Assert.IsTrue(verbEx.IsMatch("http://google.com"), "Should match url address");
+        }	
 
-		[TestMethod]
-		public void Or_VerbalExpressionsUrlOrVerbalExpressionEmail_DoesMatchEmailAndUrl()
-		{
-			verbEx.Add(VerbalExpressions.url)
-                .Or(VerbalExpressionsEnum.email);
+        [TestMethod]
+        public void Then_VerbalExpressionsUrl_DoesNotMatchEmail()
+        {
+            verbEx.StartOfLine().Then(CommonRegex.Url);
+
+            Assert.IsFalse(verbEx.IsMatch("test@github.com"), "Should not match email address");
+        }
+
+        [TestMethod]
+        public void Or_VerbalExpressionsUrlOrVerbalExpressionEmail_DoesMatchEmailAndUrl()
+        {
+            verbEx.Add(CommonRegex.Url)
+                .Or(CommonRegex.Email);
 
             Console.WriteLine(verbEx);
-		    Assert.IsTrue(verbEx.IsMatch("test@github.com"), "Should match email address");
-		    Assert.IsTrue(verbEx.IsMatch("http://www.google.com"), "Should match url address");
-		}
-	}
+            Assert.IsTrue(verbEx.IsMatch("test@github.com"), "Should match email address");
+            Assert.IsTrue(verbEx.IsMatch("http://www.google.com"), "Should match url address");
+        }
+    }
 }


### PR DESCRIPTION
- removed the reference to the file VerbalExpressionsEnum, which
  was gone anyways
- added a sealed class for collecting predefined enums that is
  a bit more usable then an enum.
- refactored the given class and tests to use the new CommonRegex
  class.

Note:  Unfortunately VS2012 was a bit harsh with the formatting, sorry! Try the "ignore whitespace" when you review this with your favorite tool.
