### PR TITLE
Add BeginCapture with a name of group and method to retrieve value captured.

### DIFF
--- a/VerbalExpressions/VerbalExpressions.cs
+++ b/VerbalExpressions/VerbalExpressions.cs
@@ -103,6 +103,15 @@ namespace CSharpVerbalExpressions
             return PatternRegex.ToString();
         }
 
+        public string Capture(string toTest, string groupName)
+        {
+            if (!Test(toTest))
+                return null;
+
+            var match=PatternRegex.Match(toTest);
+            return match.Groups[groupName].Value;
+        }
+
         #endregion Helpers
 
         #region Expression Modifiers
@@ -343,6 +352,11 @@ namespace CSharpVerbalExpressions
         public VerbalExpressions BeginCapture()
         {
             return Add("(", false);
+        }
+
+        public VerbalExpressions BeginCapture(string groupName)
+        {
+            return Add("(?<", false).Add(groupName,true).Add(">",false);
         }
 
         public VerbalExpressions EndCapture()

--- a/VerbalExpressionsUnitTests/CaptureTests.cs
+++ b/VerbalExpressionsUnitTests/CaptureTests.cs
@@ -39,6 +39,25 @@ namespace VerbalExpressionsUnitTests {
             Assert.AreEqual( @"(\w+)\s(\1)", verbEx.ToString() );
             Assert.IsTrue( verbEx.Test( TEST_STRING ), "There is no duplicates in the textString." );
         }
+
+        [Test]
+        public void BeginCaptureWithName_CreateRegexGroupNameAsExpected()
+        {
+            // Arrange
+            VerbalExpressions verbEx = VerbalExpressions.DefaultExpression;
+
+            // Act
+            verbEx.Add("COD")
+                .BeginCapture("GroupNumber")
+                .Any("0-9")
+                .RepeatPrevious(3)
+                .EndCapture()
+                .Add("END");
+
+            // Assert
+            Assert.AreEqual( @"COD(?<GroupNumber>[0-9]{3})END",verbEx.ToString());
+            Assert.AreEqual( "123", verbEx.Capture("COD123END","GroupNumber"));
+        }
     }
 
 }


### PR DESCRIPTION
· Add BeginCapture with a name of group.
· Add a Capture method to retrieve value of a name group.

Example:
To extract 123 from this string "COD123END"

verbEx.Add("COD")
                .BeginCapture("GroupNumber")
                .Any("0-9")
                .RepeatPrevious(3)
                .EndCapture()
                .Add("END");

verbEx.Capture("COD123END","GroupNumber") // return 123
