### PR TITLE
Removed unnecessary overload of VerbalExpressions.Add

### DIFF
--- a/VerbalExpressions/VerbalExpressions.cs
+++ b/VerbalExpressions/VerbalExpressions.cs
@@ -106,16 +106,6 @@ namespace CSharpVerbalExpressions
 
         #region Expression Modifiers
 
-        public VerbalExpressions Add(string value)
-        {
-            if (object.ReferenceEquals(value, null))
-            {
-                throw new ArgumentNullException("value");
-            }
-
-            return Add(value, true);
-        }
-
         public VerbalExpressions Add(CommonRegex commonRegex)
         {
             return Add(commonRegex.Name, false);


### PR DESCRIPTION
Hello there,

During our homework assignment with your repo (see details [here](https://github.com/fenyopeti/CSharpVerbalExpressions/wiki)) I have found a little something that I think deserves it's pull request.

So you have these (and some other) overloads for VerbalExpressions.Add:

* Add(string value) {...}
* Add(string value, bool sanitize = true) {...}

Now, if I were to call Add("something") which overload is called? It's not clear at first glance.

When I took a second look, I saw that the first overload calls the second one anyways, so it is completely unnecessary. I think it can be safely removed - all your tests pass afterwards.